### PR TITLE
Json to Csv conversion tool

### DIFF
--- a/jsonToCsv.py
+++ b/jsonToCsv.py
@@ -1,0 +1,49 @@
+
+from argparse import ArgumentParser
+from os import path
+import sys
+import csv
+import json
+
+# utc_offset, location, followers_count, verified, lang from user
+column_names = ['created_at', 'text', 'reply_count', 'retweet_count', 'favorite_count', 'utc_offset', 'location', 'followers_count', 'verified', 'lang', 'geo', 'coordinates', 'place']
+user_colums = ['utc_offset', 'location', 'followers_count', 'verified']
+
+def filesToCsv(files, outputDir='./'):
+    for filename in files:
+        outputName = path.join(path.abspath(outputDir), path.basename('%s.csv' % filename))
+        with open(filename, 'r') as inp:
+            with open(outputName, 'w') as outp:
+                writer = csv.DictWriter(outp, fieldnames=column_names)
+                writer.writeheader()
+                for line in inp:
+                    j = json.loads(line)
+                    data = dict()
+                    try:
+                        userData = j['user']
+                    except:
+                        pass
+                    for col in column_names:
+                        if col in user_colums:
+                            try:
+                                data[col] = userData[col]
+                            except:
+                                pass
+                        else:
+                            try:
+                                data[col] = j[col]
+                            except:
+                                pass
+                    writer.writerow(data)
+
+def main():
+    parser = ArgumentParser(usage='%(prog)s [<sourceOne> sourceTwo [...]] [options...]', description='Json to CSV converter.')
+    parser.add_argument('sourceFiles', nargs= '+', help='Files to parse.')
+    parser.add_argument('-d', default='./', help='Where to dump output files')
+    parsed = parser.parse_args(sys.argv[1:])
+    if not path.exists(parsed.d):
+        exit('Error! %s is not a valid dir.' % parsed.d)
+    filesToCsv(parsed.sourceFiles, outputDir=parsed.d)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Only pulls the following fields:
```python
column_names = ['created_at', 'text', 'reply_count', 'retweet_count', 'favorite_count', 'utc_offset', 'location', 'followers_count', 'verified', 'lang',  'geo', 'coordinates', 'place']
```

Running `$python3 jsonToCsv.py -h` yields:
```
usage: jsonToCsv.py [<sourceOne> sourceTwo [...]] [options...]

Json to CSV converter.

positional arguments:
  sourceFiles  Files to parse.

optional arguments:
  -h, --help   show this help message and exit
  -d D         Where to dump output files
```